### PR TITLE
Add 3-bit K-quants

### DIFF
--- a/quantizer.cpp
+++ b/quantizer.cpp
@@ -1,5 +1,4 @@
 #include <torch/extension.h>
-#include <vector>
 #include "quant.h"
 
 torch::Tensor quantize_q2_k(torch::Tensor& input) {

--- a/quantizer.cpp
+++ b/quantizer.cpp
@@ -34,6 +34,39 @@ torch::Tensor quantize_q2_k(torch::Tensor& input) {
   return output;
 }
 
+torch::Tensor quantize_q3_k(torch::Tensor& input) {
+  // Row-major quantization (equivalent to block size [1, 256]) 
+  // of input tensor using Q3_K scheme.
+  TORCH_CHECK(input.ndimension() == 2, "input must be 2D");
+  TORCH_CHECK(input.size(1) % QK_K == 0, "ncols must be divisible by QK_K");
+  TORCH_CHECK(input.dtype() == torch::kFloat32, "input must be float32");
+  if (!input.is_contiguous()) {
+    input = input.contiguous();
+  }
+  const int64_t nrows = input.size(0);
+  const int64_t ncols = input.size(1);
+  const int64_t blocks_per_row = ncols / QK_K;
+  const int64_t block_size = sizeof(block_q3_K);
+  
+  auto options = torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCPU);
+  auto output = torch::empty({nrows, blocks_per_row * block_size}, options);
+  
+  const float* input_ptr = input.data_ptr<float>();
+  uint8_t* output_ptr = output.data_ptr<uint8_t>();
+
+  // Parallelize over rows
+  #pragma omp parallel for
+  for (int64_t row = 0; row < nrows; row++) {
+    const float* row_input = input_ptr + row * ncols;
+    block_q3_K* row_output = reinterpret_cast<block_q3_K*>(output_ptr + row * blocks_per_row * block_size);
+
+    quantize_row_q3_K_ref(row_input, row_output, ncols);
+  }
+  
+  return output;
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("quantize_q2_k", &quantize_q2_k, "Quantize a tensor to Q2_K format");
+  m.def("quantize_q3_k", &quantize_q3_k, "Quantize a tensor to Q3_K format");
 } 

--- a/quantizer.py
+++ b/quantizer.py
@@ -1,9 +1,10 @@
 import torch
 import quantizer_cpp
+from typing import Literal
 
-def quantize_q2_k(tensor: torch.Tensor) -> torch.Tensor:
+def k_quantize(tensor: torch.Tensor, method: Literal["q2_k", "q3_k"]) -> torch.Tensor:
   """
-  Quantize a 2D float32 tensor to Q2_K format.
+  Quantize a 2D float32 tensor to Q2_K or Q3_K format.
   
   Args:
     tensor: Input tensor of shape (M, N) where N must be a multiple of 256
@@ -11,4 +12,9 @@ def quantize_q2_k(tensor: torch.Tensor) -> torch.Tensor:
   Returns:
     Quantized tensor of type uint8 and shape (M, sizeof(block_q2_K) * N/256) containing the block_q2_K data
   """ 
-  return quantizer_cpp.quantize_q2_k(tensor) 
+  if method == "q2_k":
+    return quantizer_cpp.quantize_q2_k(tensor) 
+  elif method == "q3_k":
+    return quantizer_cpp.quantize_q3_k(tensor) 
+  else:
+    raise ValueError(f"Invalid method: {method}")

--- a/src/codec.cpp
+++ b/src/codec.cpp
@@ -14,6 +14,7 @@ std::string quant_to_string(Quant quant) {
     case Quant::F16: return "F16";
     case Quant::F8E5M2: return "F8_E5M2";
     case Quant::Q2_K: return "Q2_K";
+    case Quant::Q3_K: return "Q3_K";
   }
   __builtin_unreachable();
 }
@@ -27,6 +28,8 @@ std::optional<Quant> string_to_quant(const std::string& quant_str) {
     return Quant::F8E5M2;
   } else if (quant_str == "Q2_K") {
     return Quant::Q2_K;
+  } else if (quant_str == "Q3_K") {
+    return Quant::Q3_K;
   } else {
     return std::nullopt;
   }
@@ -42,6 +45,7 @@ double bits_per_weight(Quant quant, size_t blockwise_quant_size) {
     case Quant::F16: return 2;
     case Quant::F8E5M2: return (4 + blockwise_quant_size) / blockwise_quant_size;
     case Quant::Q2_K: return 2.5625;
+    case Quant::Q3_K: return 3.4375;
   }
   __builtin_unreachable();
 }
@@ -52,8 +56,13 @@ CodecDType quant_to_codec_dtype(Quant quant) {
     case Quant::F16: return CodecDType::F16;
     case Quant::F8E5M2: return CodecDType::F8E5M2;
     case Quant::Q2_K: return CodecDType::U8;
+    case Quant::Q3_K: return CodecDType::U8;
   }
   __builtin_unreachable();
+}
+
+bool is_k_quant(Quant quant) {
+  return quant == Quant::Q2_K || quant == Quant::Q3_K;
 }
 
 std::string codec_dtype_to_string(CodecDType dtype) {

--- a/src/codec.h
+++ b/src/codec.h
@@ -81,12 +81,14 @@ enum class Quant {
   F16,
   F8E5M2,
   Q2_K, // 2-bit llama.cpp K-quants
+  Q3_K, // 3-bit llama.cpp K-quants
 };
 
 std::string quant_to_string(Quant quant);
 std::optional<Quant> string_to_quant(const std::string& quant_str);
 double bits_per_weight(Quant quant, size_t blockwise_quant_size);
 CodecDType quant_to_codec_dtype(Quant quant);
+bool is_k_quant(Quant quant);
 
 struct Tensor {
   std::string name;

--- a/src/infer.cpp
+++ b/src/infer.cpp
@@ -1092,16 +1092,19 @@ template void Block::_block_cpu<float>(InferenceState&, int, int, int, int) cons
 template void Block::_block_cpu<f16_t>(InferenceState&, int, int, int, int) const;
 template void Block::_block_cpu<f8e5m2_t>(InferenceState&, int, int, int, int) const;
 template void Block::_block_cpu<block_q2_K>(InferenceState&, int, int, int, int) const;
+template void Block::_block_cpu<block_q3_K>(InferenceState&, int, int, int, int) const;
 
 template void BlockMHA::_attention_impl<float>(InferenceState&, int, int, int, int) const;
 template void BlockMHA::_attention_impl<f16_t>(InferenceState&, int, int, int, int) const;
 template void BlockMHA::_attention_impl<f8e5m2_t>(InferenceState&, int, int, int, int) const;
 template void BlockMHA::_attention_impl<block_q2_K>(InferenceState&, int, int, int, int) const;
+template void BlockMHA::_attention_impl<block_q3_K>(InferenceState&, int, int, int, int) const;
 
 template void BlockMLA::_attention_impl<float>(InferenceState&, int, int, int, int) const;
 template void BlockMLA::_attention_impl<f16_t>(InferenceState&, int, int, int, int) const;
 template void BlockMLA::_attention_impl<f8e5m2_t>(InferenceState&, int, int, int, int) const;
 template void BlockMLA::_attention_impl<block_q2_K>(InferenceState&, int, int, int, int) const;
+template void BlockMLA::_attention_impl<block_q3_K>(InferenceState&, int, int, int, int) const;
 
 void Model::_copy_embedding(InferenceState& s, int token) {
   const Config& c = *config;

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -196,6 +196,7 @@ void* check_tensor(const Tensor* tensor, Quant weight_quant, std::array<int, 4> 
         block_size = sizeof(block_q3_K);
         break;
       }
+      default: {}
     }
     size_t total_blocks = numel / QK_K;
     size_t total_bytes = total_blocks * block_size;

--- a/src/quant.cpp
+++ b/src/quant.cpp
@@ -29,6 +29,8 @@ SOFTWARE.
 
 #include <cassert>
 
+#define GROUP_MAX_EPS 1e-15f
+
 static inline int nearest_int(float fval) {
   assert(fabsf(fval) <= 4194303.f);
   float val = fval + 12582912.f;
@@ -242,6 +244,373 @@ void dequantize_row_q2_K(const block_q2_K * __restrict__ x, float * __restrict__
       q += 32;
     }
   }
+}
+
+static float make_q3_quants(int n, int nmax, const float * __restrict__ x, int8_t * __restrict__ L, bool do_rmse) {
+  float max = 0;
+  float amax = 0;
+  for (int i = 0; i < n; ++i) {
+    float ax = fabsf(x[i]);
+    if (ax > amax) { amax = ax; max = x[i]; }
+  }
+  if (amax < GROUP_MAX_EPS) { // all zero
+    for (int i = 0; i < n; ++i) { L[i] = 0; }
+    return 0.f;
+  }
+  float iscale = -nmax / max;
+  if (do_rmse) {
+    float sumlx = 0;
+    float suml2 = 0;
+    for (int i = 0; i < n; ++i) {
+      int l = nearest_int(iscale * x[i]);
+      l = std::max(-nmax, std::min(nmax-1, l));
+      L[i] = l;
+      float w = x[i]*x[i];
+      sumlx += w*x[i]*l;
+      suml2 += w*l*l;
+    }
+    for (int itry = 0; itry < 5; ++itry) {
+      int n_changed = 0;
+      for (int i = 0; i < n; ++i) {
+        float w = x[i]*x[i];
+        float slx = sumlx - w*x[i]*L[i];
+        if (slx > 0) {
+          float sl2 = suml2 - w*L[i]*L[i];
+          int new_l = nearest_int(x[i] * sl2 / slx);
+          new_l = std::max(-nmax, std::min(nmax-1, new_l));
+          if (new_l != L[i]) {
+            slx += w*x[i]*new_l;
+            sl2 += w*new_l*new_l;
+            if (sl2 > 0 && slx*slx*suml2 > sumlx*sumlx*sl2) {
+              L[i] = new_l; sumlx = slx; suml2 = sl2;
+              ++n_changed;
+            }
+          }
+        }
+      }
+      if (!n_changed) {
+        break;
+      }
+    }
+    for (int i = 0; i < n; ++i) {
+        L[i] += nmax;
+    }
+    return sumlx / suml2;
+  }
+  for (int i = 0; i < n; ++i) {
+      int l = nearest_int(iscale * x[i]);
+      l = std::max(-nmax, std::min(nmax-1, l));
+      L[i] = l + nmax;
+  }
+  return 1/iscale;
+}
+
+void quantize_row_q3_K_ref(const float * __restrict__ x, block_q3_K * __restrict__ y, int64_t k) {
+  assert(k % QK_K == 0);
+  const int nb = k / QK_K;
+
+  int8_t L[QK_K];
+  float scales[QK_K / 16];
+
+  for (int i = 0; i < nb; i++) {
+
+    float max_scale = 0;
+    float amax = 0;
+    for (int j = 0; j < QK_K/16; ++j) {
+      scales[j] = make_q3_quants(16, 4, x + 16*j, L + 16*j, true);
+      float scale = fabsf(scales[j]);
+      if (scale > amax) {
+        amax = scale; max_scale = scales[j];
+      }
+    }
+
+    memset(y[i].scales, 0, 12);
+    if (max_scale) {
+      float iscale = -32.f/max_scale;
+      for (int j = 0; j < QK_K/16; ++j) {
+        int8_t l = nearest_int(iscale*scales[j]);
+        l = std::max(-32, std::min(31, static_cast<int>(l))) + 32;
+        if (j < 8) {
+          y[i].scales[j] = l & 0xF;
+        } else {
+          y[i].scales[j-8] |= ((l & 0xF) << 4);
+        }
+        l >>= 4;
+        y[i].scales[j%4 + 8] |= (l << (2*(j/4)));
+      }
+      y[i].d = float_to_half(1/iscale);
+    } else {
+      y[i].d = float_to_half(0.f);
+    }
+
+    int8_t sc;
+    for (int j = 0; j < QK_K/16; ++j) {
+      sc = j < 8 ? y[i].scales[j] & 0xF : y[i].scales[j-8] >> 4;
+      sc = (sc | (((y[i].scales[8 + j%4] >> (2*(j/4))) & 3) << 4)) - 32;
+      float d = half_to_float(y[i].d) * sc;
+      if (!d) {
+        continue;
+      }
+      for (int ii = 0; ii < 16; ++ii) {
+        int l = nearest_int(x[16*j + ii]/d);
+        l = std::max(-4, std::min(3, l));
+        L[16*j + ii] = l + 4;
+      }
+    }
+
+    memset(y[i].hmask, 0, QK_K/8);
+    // We put the high-bit for the 1st 8 quants into bit 0, the next 8 into bit 1, etc.
+    int m = 0;
+    uint8_t hm = 1;
+    for (int j = 0; j < QK_K; ++j) {
+      if (L[j] > 3) {
+        y[i].hmask[m] |= hm;
+        L[j] -= 4;
+      }
+      if (++m == QK_K/8) {
+        m = 0; hm <<= 1;
+      }
+    }
+    for (int j = 0; j < QK_K; j += 128) {
+      for (int l = 0; l < 32; ++l) {
+        y[i].qs[j/4 + l] = L[j + l] | (L[j + l + 32] << 2) | (L[j + l + 64] << 4) | (L[j + l + 96] << 6);
+      }
+    }
+
+    x += QK_K;
+  }
+}
+
+void dequantize_row_q3_K(const block_q3_K * __restrict__ x, float * __restrict__ y, int64_t k) {
+    assert(k % QK_K == 0);
+    const int nb = k / QK_K;
+
+    const uint32_t kmask1 = 0x03030303;
+    const uint32_t kmask2 = 0x0f0f0f0f;
+
+    uint32_t aux[4];
+    const int8_t * scales = (const int8_t*)aux;
+
+    for (int i = 0; i < nb; i++) {
+
+        const float d_all = half_to_float(x[i].d);
+
+        const uint8_t * __restrict__ q = x[i].qs;
+        const uint8_t * __restrict__ hm = x[i].hmask;
+        uint8_t m = 1;
+
+        memcpy(aux, x[i].scales, 12);
+        uint32_t tmp = aux[2];
+        aux[2] = ((aux[0] >> 4) & kmask2) | (((tmp >> 4) & kmask1) << 4);
+        aux[3] = ((aux[1] >> 4) & kmask2) | (((tmp >> 6) & kmask1) << 4);
+        aux[0] = (aux[0] & kmask2) | (((tmp >> 0) & kmask1) << 4);
+        aux[1] = (aux[1] & kmask2) | (((tmp >> 2) & kmask1) << 4);
+
+        int is = 0;
+        float dl;
+        for (int n = 0; n < QK_K; n += 128) {
+            int shift = 0;
+            for (int j = 0; j < 4; ++j) {
+
+                dl = d_all * (scales[is++] - 32);
+                for (int l = 0; l < 16; ++l) {
+                    *y++ = dl * ((int8_t)((q[l+ 0] >> shift) & 3) - ((hm[l+ 0] & m) ? 0 : 4));
+                }
+
+                dl = d_all * (scales[is++] - 32);
+                for (int l = 0; l < 16; ++l) {
+                    *y++ = dl * ((int8_t)((q[l+16] >> shift) & 3) - ((hm[l+16] & m) ? 0 : 4));
+                }
+
+                shift += 2;
+                m <<= 1;
+            }
+            q += 32;
+        }
+
+    }
+}
+
+void ggml_vec_dot_q3_K_q8_K(int n, float * __restrict__ s, const void * __restrict__ vx, const void * __restrict__ vy) {
+  assert(n % QK_K == 0);
+
+  const uint32_t kmask1 = 0x03030303;
+  const uint32_t kmask2 = 0x0f0f0f0f;
+
+  const block_q3_K * __restrict__ x = vx;
+  const block_q8_K * __restrict__ y = vy;
+
+  const int nb = n / QK_K;
+
+#if defined __AVX2__
+
+  const __m256i m3 = _mm256_set1_epi8(3);
+  const __m256i mone = _mm256_set1_epi8(1);
+  const __m128i m32 = _mm_set1_epi8(32);
+
+  __m256 acc = _mm256_setzero_ps();
+
+  uint32_t aux[3];
+
+  for (int i = 0; i < nb; ++i) {
+
+    const float d = y[i].d * half_to_float(x[i].d);
+
+    const uint8_t * __restrict__ q3 = x[i].qs;
+    const int8_t  * __restrict__ q8 = y[i].qs;
+
+    // Set up scales
+    memcpy(aux, x[i].scales, 12);
+    __m128i scales128 = _mm_set_epi32(
+            ((aux[1] >> 4) & kmask2) | (((aux[2] >> 6) & kmask1) << 4),
+            ((aux[0] >> 4) & kmask2) | (((aux[2] >> 4) & kmask1) << 4),
+            (aux[1] & kmask2) | (((aux[2] >> 2) & kmask1) << 4),
+            (aux[0] & kmask2) | (((aux[2] >> 0) & kmask1) << 4));
+    scales128 = _mm_sub_epi8(scales128, m32);
+    const __m256i all_scales = _mm256_cvtepi8_epi16(scales128);
+    const __m128i l_scales = _mm256_extracti128_si256(all_scales, 0);
+    const __m128i h_scales = _mm256_extracti128_si256(all_scales, 1);
+    const __m256i scales[2] = {MM256_SET_M128I(l_scales, l_scales), MM256_SET_M128I(h_scales, h_scales)};
+
+    // high bit
+    const __m256i hbits = _mm256_loadu_si256((const __m256i*)x[i].hmask);
+
+    // integer accumulator
+    __m256i sumi = _mm256_setzero_si256();
+
+    int bit = 0;
+    int is  = 0;
+
+    for (int j = 0; j < QK_K/128; ++j) {
+      // load low 2 bits
+      const __m256i q3bits = _mm256_loadu_si256((const __m256i*)q3); q3 += 32;
+
+      // prepare low and high bits
+      const __m256i q3l_0 = _mm256_and_si256(q3bits, m3);
+      const __m256i q3h_0 = _mm256_slli_epi16(_mm256_srli_epi16(_mm256_andnot_si256(hbits, _mm256_slli_epi16(mone, bit)), bit), 2);
+      ++bit;
+
+      const __m256i q3l_1 = _mm256_and_si256(_mm256_srli_epi16(q3bits, 2), m3);
+      const __m256i q3h_1 = _mm256_slli_epi16(_mm256_srli_epi16(_mm256_andnot_si256(hbits, _mm256_slli_epi16(mone, bit)), bit), 2);
+      ++bit;
+
+      const __m256i q3l_2 = _mm256_and_si256(_mm256_srli_epi16(q3bits, 4), m3);
+      const __m256i q3h_2 = _mm256_slli_epi16(_mm256_srli_epi16(_mm256_andnot_si256(hbits, _mm256_slli_epi16(mone, bit)), bit), 2);
+      ++bit;
+
+      const __m256i q3l_3 = _mm256_and_si256(_mm256_srli_epi16(q3bits, 6), m3);
+      const __m256i q3h_3 = _mm256_slli_epi16(_mm256_srli_epi16(_mm256_andnot_si256(hbits, _mm256_slli_epi16(mone, bit)), bit), 2);
+      ++bit;
+
+      // load Q8 quants
+      const __m256i q8_0 = _mm256_loadu_si256((const __m256i*)q8); q8 += 32;
+      const __m256i q8_1 = _mm256_loadu_si256((const __m256i*)q8); q8 += 32;
+      const __m256i q8_2 = _mm256_loadu_si256((const __m256i*)q8); q8 += 32;
+      const __m256i q8_3 = _mm256_loadu_si256((const __m256i*)q8); q8 += 32;
+
+      // Dot product: we multiply the 2 low bits and 1 high bit part separately, so we can use _mm256_maddubs_epi16,
+      // and then subtract. The high bit part has the 2 already subtracted (and so, it is zero if the high bit was not set,
+      // and 2 if the high bit was set)
+      __m256i q8s_0 = _mm256_maddubs_epi16(q3h_0, q8_0);
+      __m256i q8s_1 = _mm256_maddubs_epi16(q3h_1, q8_1);
+      __m256i q8s_2 = _mm256_maddubs_epi16(q3h_2, q8_2);
+      __m256i q8s_3 = _mm256_maddubs_epi16(q3h_3, q8_3);
+
+      __m256i p16_0 = _mm256_maddubs_epi16(q3l_0, q8_0);
+      __m256i p16_1 = _mm256_maddubs_epi16(q3l_1, q8_1);
+      __m256i p16_2 = _mm256_maddubs_epi16(q3l_2, q8_2);
+      __m256i p16_3 = _mm256_maddubs_epi16(q3l_3, q8_3);
+
+      p16_0 = _mm256_sub_epi16(p16_0, q8s_0);
+      p16_1 = _mm256_sub_epi16(p16_1, q8s_1);
+      p16_2 = _mm256_sub_epi16(p16_2, q8s_2);
+      p16_3 = _mm256_sub_epi16(p16_3, q8s_3);
+
+      // multiply with scales
+      p16_0 = _mm256_madd_epi16(_mm256_shuffle_epi8(scales[j], get_scale_shuffle_q3k(is + 0)), p16_0);
+      p16_1 = _mm256_madd_epi16(_mm256_shuffle_epi8(scales[j], get_scale_shuffle_q3k(is + 1)), p16_1);
+      p16_2 = _mm256_madd_epi16(_mm256_shuffle_epi8(scales[j], get_scale_shuffle_q3k(is + 2)), p16_2);
+      p16_3 = _mm256_madd_epi16(_mm256_shuffle_epi8(scales[j], get_scale_shuffle_q3k(is + 3)), p16_3);
+
+      // accumulate
+      p16_0 = _mm256_add_epi32(p16_0, p16_1);
+      p16_2 = _mm256_add_epi32(p16_2, p16_3);
+      sumi  = _mm256_add_epi32(sumi, _mm256_add_epi32(p16_0, p16_2));
+
+    }
+
+    // multiply with block scale and accumulate
+    acc = _mm256_fmadd_ps(_mm256_broadcast_ss(&d), _mm256_cvtepi32_ps(sumi), acc);
+
+  }
+
+  *s = hsum_float_8(acc);
+
+#else
+  // scalar version
+  // This function is written like this so the compiler can manage to vectorize most of it
+  // Using -Ofast, GCC and clang manage to produce code that is within a factor of 2 or so from the
+  // manually vectorized version above. Every other version I tried would run at least 4 times slower.
+  // The ideal situation would be if we could just write the code once, and the compiler would
+  // automatically produce the best possible set of machine instructions, instead of us having to manually
+  // write vectorized versions for AVX, ARM_NEON, etc.
+
+  int8_t  aux8[QK_K];
+  int16_t aux16[8];
+  float   sums [8];
+  int32_t aux32[8];
+  memset(sums, 0, 8*sizeof(float));
+
+  uint32_t auxs[4];
+  const int8_t * scales = (const int8_t*)auxs;
+
+  float sumf = 0;
+  for (int i = 0; i < nb; ++i) {
+    const uint8_t * __restrict__ q3 = x[i].qs;
+    const uint8_t * __restrict__ hm = x[i].hmask;
+    const  int8_t * __restrict__ q8 = y[i].qs;
+    memset(aux32, 0, 8*sizeof(int32_t));
+    int8_t * __restrict__ a = aux8;
+    uint8_t m = 1;
+    for (int j = 0; j < QK_K; j += 128) {
+      for (int l = 0; l < 32; ++l) a[l] = q3[l] & 3;
+      for (int l = 0; l < 32; ++l) a[l] -= (hm[l] & m ? 0 : 4);
+      a += 32; m <<= 1;
+      for (int l = 0; l < 32; ++l) a[l] = (q3[l] >> 2) & 3;
+      for (int l = 0; l < 32; ++l) a[l] -= (hm[l] & m ? 0 : 4);
+      a += 32; m <<= 1;
+      for (int l = 0; l < 32; ++l) a[l] = (q3[l] >> 4) & 3;
+      for (int l = 0; l < 32; ++l) a[l] -= (hm[l] & m ? 0 : 4);
+      a += 32; m <<= 1;
+      for (int l = 0; l < 32; ++l) a[l] = (q3[l] >> 6) & 3;
+      for (int l = 0; l < 32; ++l) a[l] -= (hm[l] & m ? 0 : 4);
+      a += 32; m <<= 1;
+      q3 += 32;
+    }
+    a = aux8;
+
+    memcpy(auxs, x[i].scales, 12);
+    uint32_t tmp = auxs[2];
+    auxs[2] = ((auxs[0] >> 4) & kmask2) | (((tmp >> 4) & kmask1) << 4);
+    auxs[3] = ((auxs[1] >> 4) & kmask2) | (((tmp >> 6) & kmask1) << 4);
+    auxs[0] = (auxs[0] & kmask2) | (((tmp >> 0) & kmask1) << 4);
+    auxs[1] = (auxs[1] & kmask2) | (((tmp >> 2) & kmask1) << 4);
+    for (int j = 0; j < QK_K/16; ++j) {
+      for (int l = 0; l < 8; ++l) aux16[l] = q8[l] * a[l];
+      for (int l = 0; l < 8; ++l) aux32[l] += (scales[j] - 32) * aux16[l];
+      q8 += 8; a += 8;
+      for (int l = 0; l < 8; ++l) aux16[l] = q8[l] * a[l];
+      for (int l = 0; l < 8; ++l) aux32[l] += (scales[j] - 32) * aux16[l];
+      q8 += 8; a += 8;
+    }
+    const float d = half_to_float(x[i].d) * y[i].d;
+    for (int l = 0; l < 8; ++l) sums[l] += d * aux32[l];
+  }
+  for (int l = 0; l < 8; ++l) sumf += sums[l];
+  *s = sumf;
+
+#endif
+
 }
 
 void quantize_row_q8_K_ref(const float * __restrict__ x, block_q8_K * __restrict__ y, int64_t k) {

--- a/src/quant.cpp
+++ b/src/quant.cpp
@@ -437,8 +437,8 @@ void ggml_vec_dot_q3_K_q8_K(int n, float * __restrict__ s, const void * __restri
   const uint32_t kmask1 = 0x03030303;
   const uint32_t kmask2 = 0x0f0f0f0f;
 
-  const block_q3_K * __restrict__ x = vx;
-  const block_q8_K * __restrict__ y = vy;
+  const block_q3_K * __restrict__ x = (const block_q3_K*)vx;
+  const block_q8_K * __restrict__ y = (const block_q8_K*)vy;
 
   const int nb = n / QK_K;
 


### PR DESCRIPTION
Adds support for llama.cpp 3-bit K-quants (Q3_K). This is a 3.4375-bits-per-weight quantization scheme similarly using block and super-block scales. When quantized with Q3_K, DeepSeek-V3 (650GB) becomes 269GB. Using MHA, I get 3.2 tok/s on my test machine (AWS r6a.12xlarge, 16 threads) compared to 4.01 tok/s on Q2_K but higher perplexity. 

Example preparation + generation:
```
$ git clone git@hf.co:deepseek-ai/DeepSeek-V3-Base
$ python convert.py --quant q3_k v3-base-q3_k DeepSeek-V3-Base/
$ make && OMP_NUM_THREADS=16 sudo ./build/main v3-base-q3_k -i "What is a large language model?" -m c -t 0.35 -n 128 -L
loading data from file: v3-base-q3_k/shard_000.dseek
read metadata {"act_type":"silu","arch":"DeepseekV3ForCausalLM","bos_token_id":"0","dim":"7168","eos_token_id":"1","first_k_dense_replace":"3","hidden_dim":"18432","kv_lora_rank":"512","max_seq_len":"163840","moe_intermediate_size":"2048","n_active_routed":"8","n_group":"8","n_heads":"128","n_layers":"61","n_routed_experts":"256","n_shared_experts":"1","norm_eps":"1e-06","norm_topk_prob":"True","norm_type":"rmsnorm","q_lora_rank":"1536","qk_nope_head_dim":"128","qk_rope_head_dim":"64","quant":"q3_k","rope_theta":"10000","routed_scaling_factor":"2.5","scoring_func":"sigmoid","topk_group":"4","topk_method":"group_limited_greedy","use_mla":"0","v_head_dim":"128","vocab_size":"129280"}
loading data from file: v3-base-q3_k/shard_001.dseek
loading data from file: v3-base-q3_k/shard_002.dseek
loading data from file: v3-base-q3_k/shard_003.dseek
loading data from file: v3-base-q3_k/shard_004.dseek
loading data from file: v3-base-q3_k/shard_005.dseek
loading data from file: v3-base-q3_k/shard_006.dseek
loading data from file: v3-base-q3_k/shard_007.dseek
loading model with quant: Q3_K
Model active bytes with full context window: 4.32437e+10
Model active bytes with no context: 1.86878e+10
Running warmup...
Warmup complete
[<s>:0][What:3085][ is:344][ a:260][ large:3226][ language:4063][ model:2645][?:33]
Encoding stats: (8 tokens, throughput: 1.7977e+308tok/s, latency: 0s/tok, total: 0s)

 A large language model is a type of artificial intelligence that can understand and generate human language. It can learn from large amounts of text and data and can produce new text based on what it has learned. Large language models are very powerful and can be used for many different purposes, such as writing, translating, summarizing, answering questions, and more. Some examples of large language models are GPT-4, BERT, and GPT-3. These models are very advanced and can create text that sounds like human writing. They can also learn from new data and improve their skills over time. Large language models are very useful and can help us with

Generation stats:
  136 tokens
  throughput: 3.2263tok/s
  latency: 0.30996s/tok
  hydrate: 2.316s
  bandwidth: 61.598GB/s
  total: 42.154s
```