### PR TITLE
Fix quality degradation after 4096 tokens

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -105,6 +105,16 @@ class Metadata:
       self.topk_method = config["topk_method"]
       if self.topk_method == "noaux_tc":
         self.topk_method = "group_limited_greedy" # TODO: support for Deepseek v3
+      
+      # rope
+      rope_scaling = config["rope_scaling"]
+      assert rope_scaling["type"] == "yarn"
+      self.rope_scaling_beta_fast = rope_scaling["beta_fast"]
+      self.rope_scaling_beta_slow = rope_scaling["beta_slow"]
+      self.rope_scaling_factor = rope_scaling["factor"]
+      self.rope_scaling_mscale = rope_scaling["mscale"]
+      self.rope_scaling_mscale_all_dim = rope_scaling["mscale_all_dim"]
+      self.rope_scaling_original_max_position_embeddings = rope_scaling["original_max_position_embeddings"]
   
   def to_dict(self):
     result = {}
@@ -146,6 +156,13 @@ class Metadata:
       result["scoring_func"] = str(self.scoring_func)
       result["topk_group"] = str(self.topk_group)
       result["topk_method"] = str(self.topk_method)
+      # rope scaling
+      result["rope_scaling_beta_fast"] = str(self.rope_scaling_beta_fast)
+      result["rope_scaling_beta_slow"] = str(self.rope_scaling_beta_slow)
+      result["rope_scaling_factor"] = str(self.rope_scaling_factor)
+      result["rope_scaling_mscale"] = str(self.rope_scaling_mscale)
+      result["rope_scaling_mscale_all_dim"] = str(self.rope_scaling_mscale_all_dim)
+      result["rope_scaling_original_max_position_embeddings"] = str(self.rope_scaling_original_max_position_embeddings)
     return result
 
 # this is a horrible gpt-2 unicode byte encoder hack from https://github.com/openai/gpt-2/blob/master/src/encoder.py#L9

--- a/src/infer.cpp
+++ b/src/infer.cpp
@@ -1271,9 +1271,10 @@ void Model::_forward_cpu(InferenceState& s, int token, int pos, InferenceMode mo
   // When decoding past the context length, keep the first few tokens in the KV cache
   // untouched as "attention sinks" while replacing the rest in ring order.
   // See StreamingLLM (https://arxiv.org/pdf/2309.17453) for more.
-  int kv_sink = pos >= c.max_seq_len ? KV_SINKS : 0;
-  int kv_pos = kv_sink + (pos - kv_sink) % (c.max_seq_len - kv_sink);
-  int kv_len = pos >= c.max_seq_len ? c.max_seq_len : pos + 1;
+  int original_max_position = c.rs_original_max_position_embeddings;
+  int kv_sink = pos >= original_max_position ? KV_SINKS : 0;
+  int kv_pos = kv_sink + (pos - kv_sink) % (original_max_position - kv_sink);
+  int kv_len = pos >= original_max_position ? original_max_position : pos + 1;
 
   // forward all layers in order
   for (auto b : blocks) {

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -116,6 +116,14 @@ void Config::from_yalm(YALMData& yalm, int context) {
     block_size[0] = std::stoi(yalm.metadata.at("quantization_block_size_0").get<std::string>());
     block_size[1] = std::stoi(yalm.metadata.at("quantization_block_size_1").get<std::string>());
   }
+
+  // RoPE scaling
+  rs_beta_fast = std::stoi(yalm.metadata.at("rope_scaling_beta_fast").get<std::string>());
+  rs_beta_slow = std::stoi(yalm.metadata.at("rope_scaling_beta_slow").get<std::string>());
+  rs_factor = std::stof(yalm.metadata.at("rope_scaling_factor").get<std::string>());
+  rs_mscale = std::stof(yalm.metadata.at("rope_scaling_mscale").get<std::string>());
+  rs_mscale_all_dim = std::stof(yalm.metadata.at("rope_scaling_mscale_all_dim").get<std::string>());
+  rs_original_max_position_embeddings = std::stoi(yalm.metadata.at("rope_scaling_original_max_position_embeddings").get<std::string>());
 }
 
 std::optional<QTensor> check_tensor(const Tensor* tensor, Quant weight_quant, std::array<int, 4> shape, const int debug_line) {

--- a/src/model.h
+++ b/src/model.h
@@ -83,6 +83,13 @@ struct Config {
   // If weights are quantized but block size is (0, 0), then we are using
   // per-tensor quantization.
   std::array<int, 2> block_size = {0, 0};
+  // RoPE scaling
+  int rs_beta_fast;
+  int rs_beta_slow;
+  float rs_factor;
+  float rs_mscale;
+  float rs_mscale_all_dim;
+  int rs_original_max_position_embeddings;
 
   // If nonzero `context` is supplied, max sequence length is limited to `context`.
   void from_yalm(YALMData& yalm, int context = 0);


### PR DESCRIPTION
While testing the perplexity of v2-lite on wikitext via #14, I noticed the model perplexity is very close to the reference for a chunk length of 4096 (6.82 vs. 6.12), but degrades severely for larger test sizes (for a chunk length of 6144: 24.4 vs. 6.97). It turns out this is because the inference max sequence length parameter (as specified by the `model_max_length` parameter in tokenizer configs of the DeepSeek huggingface repos) is not the same as the max sequence length during training, and the DeepSeek folks used [Yarn](https://arxiv.org/pdf/2309.00071) to extend it during inference. This is true for all the supported DeepSeek models (V2, V2-Lite, V3, R1).

I haven't implemented Yarn yet and instead use attention sinks (similar to [yalm](https://github.com/andrewkchan/yalm)), but the attention sinks are applied with the inference max sequence length rather than the training max sequence length. This mitigates the issue by making the attention sinks use the correct parameter, improving perplexity on the 6144-length chunk from 24.4 to 9.4. We can observe from the per-token cross-entropy that this is not perfect, and there is still some gap between deepseek.cpp with attention sinks vs. the reference implementation with Yarn:
![image](https://github.com/user-attachments/assets/9a8dcef4-72fb-4a0d-8a3e-99828c5821e7)


I hope to fix the issue properly by implementing Yarn sometime.